### PR TITLE
Add an ONNX export script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,8 @@ nvidia-cusolver-cu11==11.4.0.1
 nvidia-cusparse-cu11==11.7.4.91
 nvidia-nccl-cu11==2.14.3
 nvidia-nvtx-cu11==11.7.91
+onnx==1.21.0
+onnxruntime==1.26.0
 packaging==23.1
 pandas==2.0.3
 patsy==0.5.3

--- a/src/deep_impact/scripts/export_onnx.py
+++ b/src/deep_impact/scripts/export_onnx.py
@@ -1,0 +1,156 @@
+"""Export a trained DeepImpact checkpoint to a single-file ONNX model.
+
+Inputs : input_ids, attention_mask, token_type_ids  (int64,   [batch, seq])
+Output : impact_scores                               (float32, [batch, seq]);
+         the impact of a term is the score at its first subword token, as in
+         DeepImpact.compute_term_impacts.
+
+    python -m src.deep_impact.scripts.export_onnx \
+        --model_checkpoint_path soyuj/deeper-impact --output_path onnx/model.onnx
+"""
+import argparse
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+
+from src.deep_impact.models import DeepImpact
+
+# Two documents of different lengths, so the parity batch exercises padding and
+# attention masking (not just a single full-length sequence).
+SAMPLE_DOCUMENTS = [
+    'The presence of communication amid scientific minds was equally important '
+    'to the success of the Manhattan Project as scientific intellect was. The '
+    'only cloud hanging over the impressive achievement of the atomic '
+    'researchers and engineers is what their success truly meant; hundreds of '
+    'thousands of innocent lives obliterated.',
+    'Photosynthesis converts sunlight into chemical energy stored in glucose.',
+]
+
+
+class DeepImpactOnnxWrapper(nn.Module):
+    def __init__(self, model: DeepImpact):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, attention_mask, token_type_ids):
+        # Squeeze [batch, seq, 1] -> [batch, seq] so consumers never reshape.
+        return self.model(input_ids, attention_mask, token_type_ids).squeeze(-1)
+
+
+def export(model: DeepImpact, output_path: Path, opset: int) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    wrapper = DeepImpactOnnxWrapper(model).eval()
+
+    batch, seq = 1, 32
+    dummy_inputs = (
+        torch.zeros((batch, seq), dtype=torch.long),
+        torch.ones((batch, seq), dtype=torch.long),
+        torch.zeros((batch, seq), dtype=torch.long),
+    )
+
+    print(f'Exporting to {output_path} (opset {opset})')
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            dummy_inputs,
+            str(output_path),
+            input_names=['input_ids', 'attention_mask', 'token_type_ids'],
+            output_names=['impact_scores'],
+            dynamic_axes={
+                name: {0: 'batch', 1: 'sequence'}
+                for name in ('input_ids', 'attention_mask', 'token_type_ids', 'impact_scores')
+            },
+            opset_version=opset,
+            do_constant_folding=True,
+        )
+
+    onnx.checker.check_model(str(output_path))
+    print(f'Wrote {output_path} ({output_path.stat().st_size / 1e6:.1f} MB); onnx.checker passed')
+
+
+def _encode_padded_batch(model: DeepImpact, documents):
+    """Tokenize each document and right-pad them into one rectangular int64 batch."""
+    encodings = [model.process_document(doc) for doc in documents]
+    max_len = max(len(encoded.ids) for encoded, _ in encodings)
+    pad_id = model.config.pad_token_id
+
+    input_ids, attention_mask, token_type_ids = [], [], []
+    for encoded, _ in encodings:
+        pad = max_len - len(encoded.ids)
+        input_ids.append(encoded.ids + [pad_id] * pad)
+        attention_mask.append(encoded.attention_mask + [0] * pad)
+        token_type_ids.append(encoded.type_ids + [0] * pad)
+
+    arrays = (
+        np.array(input_ids, dtype=np.int64),
+        np.array(attention_mask, dtype=np.int64),
+        np.array(token_type_ids, dtype=np.int64),
+    )
+    return encodings, arrays
+
+
+def verify_parity(model: DeepImpact, output_path: Path, tolerance: float) -> None:
+    encodings, (input_ids, attention_mask, token_type_ids) = _encode_padded_batch(model, SAMPLE_DOCUMENTS)
+
+    # Drive both backends from the identical padded batch so the only variable
+    # is PyTorch vs ONNX Runtime.
+    with torch.no_grad():
+        torch_scores = model(
+            torch.from_numpy(input_ids),
+            torch.from_numpy(attention_mask),
+            torch.from_numpy(token_type_ids),
+        ).squeeze(-1).cpu().numpy()
+
+    session = ort.InferenceSession(str(output_path), providers=['CPUExecutionProvider'])
+    onnx_scores = session.run(
+        None,
+        {
+            'input_ids': input_ids,
+            'attention_mask': attention_mask,
+            'token_type_ids': token_type_ids,
+        },
+    )[0]
+
+    # Compare only at each term's first-subword index, the positions consumers read.
+    diffs = [
+        abs(float(torch_scores[i][j]) - float(onnx_scores[i][j]))
+        for i, (_, term_to_token_index) in enumerate(encodings)
+        for j in term_to_token_index.values()
+    ]
+    if not diffs:
+        raise SystemExit('Parity check produced no terms to compare')
+
+    max_abs_diff = max(diffs)
+    print(f'Parity vs PyTorch over {len(SAMPLE_DOCUMENTS)} documents, {len(diffs)} terms: '
+          f'max |diff| = {max_abs_diff:.3g} (tolerance {tolerance:.3g})')
+    if max_abs_diff > tolerance:
+        raise SystemExit('Parity check FAILED')
+    print('Parity check passed')
+
+
+def run(model_checkpoint_path: str, output_path: Path, opset: int, tolerance: float,
+        skip_verify: bool) -> None:
+    print(f'Loading DeepImpact checkpoint: {model_checkpoint_path}')
+    model = DeepImpact.from_pretrained(model_checkpoint_path).eval()
+    export(model, output_path, opset)
+    if not skip_verify:
+        verify_parity(model, output_path, tolerance)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Export a DeepImpact checkpoint to ONNX and verify parity with PyTorch.')
+    parser.add_argument('--model_checkpoint_path', type=str, default='soyuj/deeper-impact',
+                        help='HuggingFace Hub id or local path of the trained DeepImpact checkpoint.')
+    parser.add_argument('--output_path', type=Path, default=Path('onnx/model.onnx'),
+                        help='Destination path for the exported ONNX model.')
+    parser.add_argument('--opset', type=int, default=17, help='ONNX opset version.')
+    parser.add_argument('--tolerance', type=float, default=1e-4,
+                        help='Maximum allowed |PyTorch - ONNX Runtime| impact-score difference.')
+    parser.add_argument('--skip_verify', action='store_true', help='Skip the post-export parity check.')
+
+    run(**vars(parser.parse_args()))


### PR DESCRIPTION
## What

Adds `src/deep_impact/scripts/export_onnx.py`, a small utility that exports a trained DeepImpact checkpoint to a single-file ONNX model and verifies it against PyTorch:

```bash
python -m src.deep_impact.scripts.export_onnx \
    --model_checkpoint_path soyuj/deeper-impact \
    --output_path onnx/model.onnx
```

Also adds `onnx` and `onnxruntime` to `requirements.txt` (used only by this script).

## Why

There's currently no ONNX export of DeepImpact, which makes it awkward to run inference outside Python (ONNX Runtime from Rust/C++/JS, etc.).

`optimum-cli export onnx` can't produce a correct export here: DeepImpact sets `architectures: ["DeepImpact"]` but isn't registered with transformers' `AutoModel*`, so optimum falls back to a plain `BertModel` (via `model_type: "bert"`) and **silently drops the `impact_score_encoder` head** — emitting hidden states instead of impact scores, with no error. This script sidesteps that by tracing a thin wrapper around the real module with `torch.onnx.export`.

## What gets exported

| | name | dtype | shape |
|---|---|---|---|
| inputs | `input_ids`, `attention_mask`, `token_type_ids` | int64 | `[batch, seq]` |
| output | `impact_scores` | float32 | `[batch, seq]` |

Batch and sequence axes are dynamic (one model serves any batch size / length up to 512). A term's impact is the score at its first subword token — the same indexing `DeepImpact.compute_term_impacts` already does.

## Parity

After export, the script runs a built-in check: it feeds a padded batch of two documents through both PyTorch and ONNX Runtime and asserts the per-term scores agree.

```
Wrote onnx/model.onnx (435.8 MB); onnx.checker passed
Parity vs PyTorch over 2 documents, 45 terms: max |diff| = 5.72e-06 (tolerance 0.0001)
Parity check passed
```

Verified on the repo's pinned `torch==2.0.1` (Python 3.11). The output is a single self-contained `model.onnx` (~436 MB, no external-data sidecar).

## Companion PR

A matching PR on the Hugging Face repo uploads the exported `model.onnx` (to `onnx/model.onnx`) and adds an ONNX section to the model card: https://huggingface.co/soyuj/deeper-impact/discussions/1
